### PR TITLE
Fix topic creation by Sensor

### DIFF
--- a/packs/kafka/README.md
+++ b/packs/kafka/README.md
@@ -35,14 +35,3 @@ st2 run kafka.produce topic=meetings message='StackStorm meets Apache Kafka'
 # Send JSON-formatted message
 st2 run kafka.produce topic=test message='{"menu": {"id": "file"}}'
 ```
-
-## Known Issues
-Kafka `topic` should be registered before starting the sensor which listens on that topic.
-Publishing message to topic and then re-running sensor should work:
-```sh
-# Publishing first message automatically creates the topic
-st2 run kafka.produce topic=test message=Hello1
-st2ctl restart
-# Sensor should see new message now
-st2 run kafka.produce topic=test message=Hello2
-```

--- a/packs/kafka/rules/README.md
+++ b/packs/kafka/rules/README.md
@@ -3,31 +3,29 @@ The rules folder contains rules. See [Rules](http://docs.stackstorm.com/rules.ht
 
 ----------
 
-Example rule [`rules/parse_message.yaml`](rules/parse_message.yaml) with criteria filters based on received message from Kafka.
+Example rule [`parse_message.yaml`](parse_message.yaml) with criteria filters based on received message from Kafka.
 
-`KafkaMessageSensor` listens to `test` topic (see [config.yaml](./config.yaml)) of `localhost:9092`
+`KafkaMessageSensor` listens to `test` topic (see [config.yaml](/config.yaml)) of `localhost:9092`
 Kafka host and when new message appears, it emits `kafka.new_message` trigger into StackStorm engine.
 Additionally sensor detects if received message is JSON and converts it to object,
 to reuse in st2 rules/workflows with filters and criteria. 
 
 ##### 1. Install this pack
-
-##### 2. Create `test` topic by sending first message
 ```sh
-st2 run kafka.produce topic=test message=Hello
+st2 run packs.install packs=kafka repo_url=stackstorm/st2-kafka subtree=true register=actions,rules,sensors
 ```
 
-##### 3. Enable `parse_message` rule and `restart` sensor to listen on new created topic
+##### 2. Enable `parse_message` rule
 ```sh
-st2ctl restart
+st2 rule enable kafka.parse_message
 ```
 
-##### 4. Publish example JSON-formatted message to `test` topic on `localhost:9092` Kafka host:
+##### 3. Publish example JSON-formatted message to `test` topic on default `localhost:9092` Kafka host:
 ```sh
 st2 run kafka.produce topic=test message='{"command": "MONITOR",	"source": "HailATaxii.STIX.dShield.list",	"id": "openz2-123abcde-7641-4169-8227-3584521e1e32", "groupid": "123abcde-7641-4169-8227-3584521e1e32", "timestamp": "2015-07-16T00:00:00Z", "attributeQualification": "ALL",	"attributes": [{"attributeName": "SUBNET", "attributeValue": "99.99.99.0/24"}]}'
 ```
 
-##### 5. Verify that action from rule was executed:
+##### 4. Verify that action from rule was executed:
 ```sh
 st2 execution list --action core.local -n 5
 ```

--- a/packs/kafka/rules/README.md
+++ b/packs/kafka/rules/README.md
@@ -5,7 +5,7 @@ The rules folder contains rules. See [Rules](http://docs.stackstorm.com/rules.ht
 
 Example rule [`parse_message.yaml`](parse_message.yaml) with criteria filters based on received message from Kafka.
 
-`KafkaMessageSensor` listens to `test` topic (see [config.yaml](/config.yaml)) of `localhost:9092`
+`KafkaMessageSensor` listens to `test` topic (see [config.yaml](./../config.yaml)) of `localhost:9092`
 Kafka host and when new message appears, it emits `kafka.new_message` trigger into StackStorm engine.
 Additionally sensor detects if received message is JSON and converts it to object,
 to reuse in st2 rules/workflows with filters and criteria. 

--- a/packs/kafka/sensors/message_sensor.py
+++ b/packs/kafka/sensors/message_sensor.py
@@ -42,6 +42,18 @@ class KafkaMessageSensor(Sensor):
                                        group_id=self._group_id,
                                        bootstrap_servers=self._hosts,
                                        deserializer_class=self._try_deserialize)
+        self._ensure_topics_existence()
+
+    def _ensure_topics_existence(self):
+        """
+        Ensure that topics we're listening to exist.
+
+        Fetching metadata for a non-existent topic will automatically try to create it
+        with the default replication factor and number of partitions (default server config).
+        Otherwise Kafka server is not configured to auto-create topics and partitions.
+        """
+        map(self._consumer._client.ensure_topic_exists, self._topics)
+        self._consumer.set_topic_partitions(*self._topics)
 
     def run(self):
         """


### PR DESCRIPTION
Auto-create topics we're listening to in sensor if they doesn't exist.

This seems to be the correct behavior, when kafka server config `auto.create.topics.enable` is set to `true` (default). From official [Apache Kafka docs](http://kafka.apache.org/documentation.html#brokerconfigs): 
>Enable auto creation of topic on the server. If this is set to true then attempts to produce data or fetch metadata for a non-existent topic will automatically create it with the default replication factor and number of partitions.

What this change does - fetches metadata from Kafka broker about topic, - this action automatically creates topic and partition. Nothing harmful.
